### PR TITLE
chore: PreCompact hookの削除

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -50,16 +50,6 @@
           }
         ]
       }
-    ],
-    "PreCompact": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "REPO=$(git rev-parse --show-toplevel 2>/dev/null || pwd); BRANCH=$(git branch --show-current 2>/dev/null); STATUS=$(git status --short 2>/dev/null | head -20); TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S'); mkdir -p \"$REPO/.claude\"; { echo \"# Pre-Compact Summary\"; echo \"\"; echo \"Timestamp: $TIMESTAMP\"; echo \"\"; echo \"## Git State\"; echo \"\"; echo \"Branch: $BRANCH\"; if [ -n \"$STATUS\" ]; then echo \"\"; echo \"Uncommitted changes:\"; echo \"$STATUS\"; else echo \"Working tree: clean\"; fi; } | tee \"$REPO/.claude/compact-summary.md\""
-          }
-        ]
-      }
     ]
   }
 }


### PR DESCRIPTION
## Summary
- compact実行時に不要な`compact-summary.md`ファイルを生成するPreCompact hookを削除

Closes #11

## Test plan
- [ ] compact実行時にファイルが生成されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)