### PR TITLE
enhance: シェル起動時にdotfiles未コミット変更の通知を追加

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -1,6 +1,9 @@
 # PATH
 export PATH="$HOME/.local/bin:$PATH"
 
+# Dotfiles
+DOTFILES_DIR=~/projects/dotfiles
+
 # History
 HISTFILE=~/.zsh_history
 HISTSIZE=10000
@@ -48,3 +51,12 @@ alias gsw='git switch'
 # Options
 setopt auto_cd
 setopt correct
+
+# Dotfiles dirty check
+_dotfiles_dirty_check() {
+    [[ -d "$DOTFILES_DIR" ]] || return
+    if [[ -n "$(git -C "$DOTFILES_DIR" status --porcelain 2>/dev/null)" ]]; then
+        print -P "%F{yellow}⚠ dotfiles に未コミットの変更があります ($DOTFILES_DIR)%f"
+    fi
+}
+_dotfiles_dirty_check


### PR DESCRIPTION
## Summary
- シェル起動時にdotfilesリポジトリの未コミット変更を検知し、黄色の警告メッセージを表示する機能を追加
- `git status --porcelain` で変更を検知し、staged/unstaged/untrackedすべてを対象とする

Closes #10

## Test plan
- [ ] dotfilesリポジトリに未コミットの変更がある状態で新しいシェルを開き、警告が表示されることを確認
- [ ] 変更がない（clean）状態でシェルを開き、何も表示されないことを確認
- [ ] `DOTFILES_DIR` が存在しないパスに変更した場合、エラーなくスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)