### PR TITLE
feat: macOSデフォルト設定のスクリプト化

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,17 @@
 SHELL := /bin/bash
 
-.PHONY: init brew link brewsync
+.PHONY: init brew link macos brewsync
 
-init: brew link
+init: brew link macos
 
 brew:
 	@bash init/brew.sh
 
 link:
 	@bash init/link.sh
+
+macos:
+	@bash init/macos.sh
 
 brewsync:
 	brew bundle dump --file=Brewfile --force

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Create symlinks with stow:
 make link
 ```
 
+Apply macOS defaults:
+
+```bash
+make macos
+```
+
 ### Maintenance
 
 Sync current Homebrew packages to Brewfile:
@@ -48,7 +54,8 @@ dotfiles/
 ├── Brewfile
 ├── init/
 │   ├── brew.sh        # Homebrew installation and package management
-│   └── link.sh        # Symlink management with stow
+│   ├── link.sh        # Symlink management with stow
+│   └── macos.sh       # macOS defaults configuration
 ├── zsh/
 │   ├── .zshrc
 │   └── .zprofile

--- a/init/macos.sh
+++ b/init/macos.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "Applying macOS defaults..."
+
+# Dock
+defaults write com.apple.dock autohide -bool true
+defaults write com.apple.dock magnification -bool true
+defaults write com.apple.dock mineffect -string "scale"
+
+# Finder
+defaults write com.apple.finder FXPreferredViewStyle -string "clmv"
+
+# Keyboard
+defaults write NSGlobalDomain KeyRepeat -int 2
+defaults write NSGlobalDomain InitialKeyRepeat -int 15
+
+# Trackpad
+defaults write com.apple.AppleMultitouchTrackpad Clicking -bool true
+defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad Clicking -bool true
+
+# Apply changes
+killall Dock Finder
+
+echo "macos.sh completed."


### PR DESCRIPTION
## Summary
- `init/macos.sh` を新規作成し、`defaults write` によるmacOS設定を再現可能にした
- Dock（自動非表示・拡大・スケールエフェクト）、Finder（カラム表示）、キーボード（高速リピート）、トラックパッド（タップクリック）の設定を含む
- Makefileに `macos` ターゲットを追加し、`make init` に組み込み

Closes #6

## Test plan
- [ ] `bash init/macos.sh` を実行してエラーなく完了することを確認
- [ ] `make macos` で同様に動作確認
- [ ] 実行後に `defaults read` で設定値が反映されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)