### PR TITLE
enhance: macOSデフォルト設定の差分チェックスクリプトを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: init brew link macos brewsync
+.PHONY: init brew link macos brewsync macoscheck
 
 init: brew link macos
 
@@ -15,3 +15,6 @@ macos:
 
 brewsync:
 	brew bundle dump --file=Brewfile --force
+
+macoscheck:
+	@bash init/macos_check.sh

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ Sync current Homebrew packages to Brewfile:
 make brewsync
 ```
 
+Check for drift between macos.sh and current macOS settings:
+
+```bash
+make macoscheck
+```
+
 ## Structure
 
 ```
@@ -55,7 +61,8 @@ dotfiles/
 ├── init/
 │   ├── brew.sh        # Homebrew installation and package management
 │   ├── link.sh        # Symlink management with stow
-│   └── macos.sh       # macOS defaults configuration
+│   ├── macos.sh       # macOS defaults configuration
+│   └── macos_check.sh # Check drift between macos.sh and current settings
 ├── zsh/
 │   ├── .zshrc
 │   └── .zprofile

--- a/init/macos_check.sh
+++ b/init/macos_check.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MACOS_SH="$SCRIPT_DIR/macos.sh"
+
+diff_count=0
+
+while IFS= read -r line; do
+    [[ "$line" =~ ^defaults\ write\ ([^\ ]+)\ ([^\ ]+)\ (-bool|-string|-int)\ (.+)$ ]] || continue
+
+    domain="${BASH_REMATCH[1]}"
+    key="${BASH_REMATCH[2]}"
+    type="${BASH_REMATCH[3]}"
+    expected="${BASH_REMATCH[4]}"
+
+    case "$type" in
+        -bool)
+            [[ "$expected" == "true" ]] && expected="1" || expected="0"
+            ;;
+        -string)
+            expected="${expected//\"/}"
+            ;;
+        -int)
+            ;;
+    esac
+
+    current=$(defaults read "$domain" "$key" 2>/dev/null || echo "<not set>")
+
+    if [[ "$current" != "$expected" ]]; then
+        echo "DIFF: $domain $key"
+        echo "  expected : $expected"
+        echo "  current  : $current"
+        diff_count=$((diff_count + 1))
+    fi
+done < "$MACOS_SH"
+
+if [[ $diff_count -eq 0 ]]; then
+    echo "差分なし: macos.sh の全設定が現在の値と一致しています。"
+else
+    echo ""
+    echo "$diff_count 件の差分があります。"
+    echo "  - macos.sh の設定をMacに適用する場合: make macos"
+    echo "  - Mac の現在値を macos.sh に反映する場合: macos.sh を手動編集してください"
+fi


### PR DESCRIPTION
## Summary
- `init/macos_check.sh` を新規作成: `macos.sh` 内の `defaults write` 行をパースし、`defaults read` の現在値と比較して差分を表示
- `Makefile` に `macoscheck` ターゲットを追加（`brewsync` と同様のメンテナンス系コマンド）
- 差分がある場合、`make macos` で適用するか `macos.sh` を手動編集するかを案内するメッセージを表示

Closes #18

## Test plan
- [ ] `make macoscheck` を実行して差分なしの場合に「差分なし」と表示されることを確認
- [ ] `macos.sh` の値を一時変更して差分が検出されることを確認
- [ ] `macos.sh` に新しい `defaults write` 行を追加した際、自動的にチェック対象になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)