### PR TITLE
feat: VS Code設定をstowパッケージとして追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,10 @@ dotfiles/
 ├── zsh/
 │   ├── .zshrc
 │   └── .zprofile
-└── git/
-    ├── .gitconfig
-    └── .gitignore_global
+├── git/
+│   ├── .gitconfig
+│   └── .gitignore_global
+└── vscode/
+    ├── settings.json
+    └── keybindings.json
 ```

--- a/init/link.sh
+++ b/init/link.sh
@@ -10,6 +10,11 @@ for pkg in "${PACKAGES[@]}"; do
     stow -v -d "$DOTFILES_DIR" -t "$HOME" --adopt "$pkg"
 done
 
+# VS Code (different target from $HOME)
+VSCODE_TARGET="$HOME/Library/Application Support/Code/User"
+echo "Linking vscode..."
+stow -v -d "$DOTFILES_DIR" -t "$VSCODE_TARGET" --adopt vscode
+
 # Restore repo versions after --adopt (repo contents take precedence)
 cd "$DOTFILES_DIR"
 git checkout -- .

--- a/vscode/keybindings.json
+++ b/vscode/keybindings.json
@@ -1,0 +1,10 @@
+[
+    {
+        "key": "shift+enter",
+        "command": "workbench.action.terminal.sendSequence",
+        "args": {
+            "text": "\u001b\r"
+        },
+        "when": "terminalFocus"
+    }
+]

--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -1,0 +1,16 @@
+{
+    "github.copilot.nextEditSuggestions.enabled": true,
+    "github.copilot.enable": {
+        "*": true,
+        "plaintext": false,
+        "markdown": true,
+        "scminput": false,
+        "dart": false
+    },
+    "security.workspace.trust.untrustedFiles": "open",
+    "explorer.confirmDragAndDrop": false,
+    "explorer.confirmDelete": false,
+    "git.enableSmartCommit": true,
+    "claudeCode.preferredLocation": "panel",
+    "workbench.startupEditor": "none"
+}


### PR DESCRIPTION
## Summary
- `vscode/` パッケージを新規作成し、`settings.json` と `keybindings.json` を収録
- `init/link.sh` に vscode 専用の stow コマンドを追加（ターゲット: `~/Library/Application Support/Code/User`）
- README の Structure に `vscode/` を追加

Closes #5

## Test plan
- [ ] `bash init/link.sh` を実行してエラーなく完了することを確認
- [ ] `ls -la ~/Library/Application\ Support/Code/User/settings.json` でシンボリックリンクが作成されていることを確認
- [ ] リンク先が `dotfiles/vscode/settings.json` を指していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)