### PR TITLE
feat: VS Code拡張機能をdotfilesで管理できるようにする

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 SHELL := /bin/bash
 
-.PHONY: init brew link macos brewsync macoscheck
+.PHONY: init brew link macos vscode-extensions brewsync macoscheck
 
-init: brew link macos
+init: brew link macos vscode-extensions
 
 brew:
 	@bash init/brew.sh
@@ -12,6 +12,9 @@ link:
 
 macos:
 	@bash init/macos.sh
+
+vscode-extensions:
+	@bash init/install-vscode-extensions.sh
 
 brewsync:
 	brew bundle dump --file=Brewfile --force

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ make init
 
 ### Setup
 
-Full setup (runs brew + link):
+Full setup (runs brew + link + macos + vscode-extensions):
 
 ```bash
 make init
@@ -38,6 +38,12 @@ Apply macOS defaults:
 make macos
 ```
 
+Install VS Code extensions from `vscode/extensions.txt`:
+
+```bash
+make vscode-extensions
+```
+
 ### Maintenance
 
 Sync current Homebrew packages to Brewfile:
@@ -59,10 +65,11 @@ dotfiles/
 ├── Makefile
 ├── Brewfile
 ├── init/
-│   ├── brew.sh        # Homebrew installation and package management
-│   ├── link.sh        # Symlink management with stow
-│   ├── macos.sh       # macOS defaults configuration
-│   └── macos_check.sh # Check drift between macos.sh and current settings
+│   ├── brew.sh                      # Homebrew installation and package management
+│   ├── link.sh                      # Symlink management with stow
+│   ├── macos.sh                     # macOS defaults configuration
+│   ├── macos_check.sh               # Check drift between macos.sh and current settings
+│   └── install-vscode-extensions.sh # Install VS Code extensions
 ├── zsh/
 │   ├── .zshrc
 │   └── .zprofile
@@ -71,5 +78,6 @@ dotfiles/
 │   └── .gitignore_global
 └── vscode/
     ├── settings.json
-    └── keybindings.json
+    ├── keybindings.json
+    └── extensions.txt
 ```

--- a/init/install-vscode-extensions.sh
+++ b/init/install-vscode-extensions.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+EXTENSIONS_FILE="$SCRIPT_DIR/../vscode/extensions.txt"
+
+if ! command -v code &>/dev/null; then
+    echo "⚠ code コマンドが見つかりません。VS Code のインストールを確認してください。"
+    exit 1
+fi
+
+echo "VS Code 拡張機能をインストールしています..."
+while IFS= read -r ext || [[ -n "$ext" ]]; do
+    [[ -z "$ext" || "$ext" == \#* ]] && continue
+    code --install-extension "$ext" --force
+done < "$EXTENSIONS_FILE"
+echo "完了しました。"

--- a/vscode/extensions.txt
+++ b/vscode/extensions.txt
@@ -1,0 +1,6 @@
+anthropic.claude-code
+github.copilot-chat
+github.vscode-github-actions
+ms-azuretools.vscode-containers
+ms-ceintl.vscode-language-pack-ja
+ms-vscode-remote.remote-containers


### PR DESCRIPTION
## Summary
- `vscode/extensions.txt` を追加し、拡張機能IDを一覧管理
- `init/install-vscode-extensions.sh` を追加し、一括インストールを可能に
- `make vscode-extensions` ターゲットを追加、`make init` にも組み込む
- README.md のセットアップ手順・構造図を更新

Closes #23

## Test plan
- [ ] `make vscode-extensions` を実行して拡張機能がインストールされることを確認
- [ ] `bash init/install-vscode-extensions.sh` を直接実行しても動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)