### PR TITLE
chore: MakefileのルールをClaude向けconventions.mdに追記する

### DIFF
--- a/.claude/rules/conventions.md
+++ b/.claude/rules/conventions.md
@@ -43,3 +43,17 @@ Format: `<prefix><concise-english-description>` (hyphens separated)
 
 - git commit / push
 - Issue・PRのステータス変更
+
+## Makefile
+
+### Script Placement
+
+初期化・セットアップ用スクリプトは `init/` ディレクトリに配置する（`scripts/` は使用しない）。
+
+### Target Order
+
+ターゲットの記載順は **Setup → Maintenance** の順とする（README の構成と一致させる）。
+
+### make init への追加基準
+
+新しいセットアップ手順を追加する場合、初期セットアップ（新しいマシンへの環境構築）に必要であれば `init:` の依存に含める。


### PR DESCRIPTION
## Summary
- `conventions.md` に `## Makefile` セクションを追加
- スクリプトは `init/` に配置するルールを明文化
- Makefileターゲットの記載順（Setup → Maintenance）を明文化
- `make init` への追加基準（初期セットアップに必要なものは含める）を明文化

Closes #25

## Test plan
- [ ] `.claude/rules/conventions.md` に `## Makefile` セクションが追記されていることを確認
- [ ] 3つのサブセクション（Script Placement / Target Order / make init への追加基準）が含まれていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)