### PR TITLE
chore: .gitignore_global をOS系のみに最小化する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .claude/settings.local.json
 .DS_Store
+.idea/

--- a/git/.gitignore_global
+++ b/git/.gitignore_global
@@ -1,3 +1,2 @@
-.idea/
-README_ja.md
-readme-sync.md
+# OS
+.DS_Store


### PR DESCRIPTION
## Summary
- `.gitignore_global` からプロジェクト固有のエントリ (`.idea/`, `README_ja.md`, `readme-sync.md`) を削除し、`.DS_Store` のみに絞る
- このリポジトリの `.gitignore` に `.idea/` を追加

Closes #29

## Test plan
- [ ] `git/.gitignore_global` に `.DS_Store` のみが含まれていることを確認
- [ ] `.gitignore` に `.idea/` が追加されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)