### PR TITLE
enhance: VS Code MCP サーバー設定を dotfiles で管理する

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,5 +79,24 @@ dotfiles/
 └── vscode/
     ├── settings.json
     ├── keybindings.json
+    ├── mcp.json           # MCP server configuration
     └── extensions.txt
 ```
+
+## MCP Server Configuration
+
+MCP server configuration is managed in `vscode/mcp.json` (symlinked to `~/Library/Application Support/Code/User/mcp.json` via `make link`).
+
+### Managed Servers
+
+| Server | URL | Auth |
+|---|---|---|
+| Atlassian Rovo MCP Server | https://mcp.atlassian.com/v1/mcp | OAuth (browser) |
+
+### Authentication
+
+On first setup, sign in to the Atlassian server from the MCP Servers section in the VS Code extensions panel (a browser window will open for Atlassian account authentication).
+
+### Not Managed
+
+`~/Library/Application Support/Code/User/mcp/` (downloaded server binary cache) is not tracked in this repository.

--- a/vscode/mcp.json
+++ b/vscode/mcp.json
@@ -1,0 +1,11 @@
+{
+    "servers": {
+        "com.atlassian/atlassian-mcp-server": {
+            "type": "http",
+            "url": "https://mcp.atlassian.com/v1/mcp",
+            "gallery": "https://api.mcp.github.com",
+            "version": "1.1.1"
+        }
+    },
+    "inputs": []
+}


### PR DESCRIPTION
## Summary

- `vscode/mcp.json` を新規追加し、Atlassian Rovo MCP Server の設定を dotfiles で管理できるようにした
- `make link` で `~/Library/Application Support/Code/User/mcp.json` にシムリンクされる（既存の stow 設定に乗せるだけで完結）
- README に MCP 設定の管理方針（管理対象サーバー・認証手順・対象外ファイル）を追記した

Closes #24

## Test plan

- [ ] `make link` を実行し、`~/Library/Application Support/Code/User/mcp.json` がシムリンクになっていることを確認
- [ ] VS Code の拡張機能パネルの「MCPサーバー - インストール済み」に Atlassian が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)