### PR TITLE
enhance: VS Code推奨設定をsettings.jsonに追加する

### DIFF
--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -12,5 +12,14 @@
     "explorer.confirmDelete": false,
     "git.enableSmartCommit": true,
     "claudeCode.preferredLocation": "panel",
-    "workbench.startupEditor": "none"
+    "workbench.startupEditor": "none",
+    "editor.fontLigatures": true,
+    "editor.formatOnSave": true,
+    "editor.rulers": [
+        100
+    ],
+    "editor.minimap.enabled": false,
+    "files.trimTrailingWhitespace": true,
+    "files.insertFinalNewline": true,
+    "files.autoSave": "onFocusChange"
 }


### PR DESCRIPTION
## Summary
- デフォルト値から変更する設定のみを `vscode/settings.json` に追加した
- リガチャ有効化、保存時フォーマット、ミニマップ非表示、行末スペース削除、ファイル末尾改行、フォーカス離脱時自動保存を設定

Closes #20

## Test plan
- [ ] VS Codeで `vscode/settings.json` を開き、シンタックスエラーがないことを確認
- [ ] 設定が VS Code に反映されていることを手動確認（フォーマット・ミニマップ等）

🤖 Generated with [Claude Code](https://claude.com/claude-code)