### PR TITLE
enhance: VS Code起動時にターミナルを自動表示する設定を追加する

### DIFF
--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -21,5 +21,6 @@
     "editor.minimap.enabled": false,
     "files.trimTrailingWhitespace": true,
     "files.insertFinalNewline": true,
-    "files.autoSave": "onFocusChange"
+    "files.autoSave": "onFocusChange",
+    "terminal.integrated.hideOnStartup": "never"
 }


### PR DESCRIPTION
## Summary
- `terminal.integrated.hideOnStartup: "never"` を `vscode/settings.json` に追加
- VS Code起動時にターミナルセッションが自動復元・表示されるようになる

Closes #32

## Test plan
- [ ] VS Codeでターミナルを開いた状態でウィンドウを閉じ、再度開いてターミナルが自動表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)