### PR TITLE
enhance: VS Code拡張機能の差分チェック・同期用makeコマンドを追加する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 SHELL := /bin/bash
 
-.PHONY: init brew link macos vscode-extensions brewsync macoscheck
+.PHONY: init brew link macos vscode-extensions macoscheck vscodecheck brewsync vscodesync
 
+# Setup
 init: brew link macos vscode-extensions
 
 brew:
@@ -16,8 +17,16 @@ macos:
 vscode-extensions:
 	@bash init/install-vscode-extensions.sh
 
+# Maintenance - Check
+macoscheck:
+	@bash init/macos_check.sh
+
+vscodecheck:
+	@bash init/vscode_check.sh
+
+# Maintenance - Sync
 brewsync:
 	brew bundle dump --file=Brewfile --force
 
-macoscheck:
-	@bash init/macos_check.sh
+vscodesync:
+	@bash init/vscode_sync.sh

--- a/README.md
+++ b/README.md
@@ -44,7 +44,21 @@ Install VS Code extensions from `vscode/extensions.txt`:
 make vscode-extensions
 ```
 
-### Maintenance
+### Maintenance - Check
+
+Check for drift between macos.sh and current macOS settings:
+
+```bash
+make macoscheck
+```
+
+Check for differences between `vscode/extensions.txt` and locally installed extensions:
+
+```bash
+make vscodecheck
+```
+
+### Maintenance - Sync
 
 Sync current Homebrew packages to Brewfile:
 
@@ -52,10 +66,10 @@ Sync current Homebrew packages to Brewfile:
 make brewsync
 ```
 
-Check for drift between macos.sh and current macOS settings:
+Sync locally installed VS Code extensions to `vscode/extensions.txt`:
 
 ```bash
-make macoscheck
+make vscodesync
 ```
 
 ## Structure
@@ -69,7 +83,9 @@ dotfiles/
 │   ├── link.sh                      # Symlink management with stow
 │   ├── macos.sh                     # macOS defaults configuration
 │   ├── macos_check.sh               # Check drift between macos.sh and current settings
-│   └── install-vscode-extensions.sh # Install VS Code extensions
+│   ├── install-vscode-extensions.sh # Install VS Code extensions
+│   ├── vscode_check.sh             # Check drift between extensions.txt and local extensions
+│   └── vscode_sync.sh              # Sync local extensions to extensions.txt
 ├── zsh/
 │   ├── .zshrc
 │   └── .zprofile

--- a/init/vscode_check.sh
+++ b/init/vscode_check.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+EXTENSIONS_FILE="$SCRIPT_DIR/../vscode/extensions.txt"
+
+if ! command -v code &>/dev/null; then
+    echo "⚠ code コマンドが見つかりません。VS Code のインストールを確認してください。"
+    exit 1
+fi
+
+local_extensions=$(code --list-extensions | sort)
+repo_extensions=$(sort "$EXTENSIONS_FILE")
+
+local_only=$(comm -23 <(echo "$local_extensions") <(echo "$repo_extensions"))
+repo_only=$(comm -13 <(echo "$local_extensions") <(echo "$repo_extensions"))
+
+diff_count=0
+
+if [[ -n "$local_only" ]]; then
+    echo "ローカルのみ（extensions.txt に未記載）:"
+    while IFS= read -r ext; do
+        echo "  + $ext"
+        diff_count=$((diff_count + 1))
+    done <<< "$local_only"
+    echo ""
+fi
+
+if [[ -n "$repo_only" ]]; then
+    echo "リポジトリのみ（ローカル未インストール）:"
+    while IFS= read -r ext; do
+        echo "  - $ext"
+        diff_count=$((diff_count + 1))
+    done <<< "$repo_only"
+    echo ""
+fi
+
+if [[ $diff_count -eq 0 ]]; then
+    echo "差分なし: extensions.txt とローカルの拡張機能は一致しています。"
+else
+    echo "$diff_count 件の差分があります。"
+    echo "  - extensions.txt の拡張機能をインストールする場合: make vscode-extensions"
+    echo "  - ローカルの状態を extensions.txt に反映する場合: make vscodesync"
+fi

--- a/init/vscode_sync.sh
+++ b/init/vscode_sync.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+EXTENSIONS_FILE="$SCRIPT_DIR/../vscode/extensions.txt"
+
+if ! command -v code &>/dev/null; then
+    echo "⚠ code コマンドが見つかりません。VS Code のインストールを確認してください。"
+    exit 1
+fi
+
+code --list-extensions | sort > "$EXTENSIONS_FILE"
+echo "extensions.txt をローカルの拡張機能で更新しました。"


### PR DESCRIPTION
## Summary
- `make vscodecheck` で `vscode/extensions.txt` とローカルの拡張機能の差分を表示するコマンドを追加
- `make vscodesync` でローカルの拡張機能を `vscode/extensions.txt` に同期するコマンドを追加
- Makefileのターゲット順を Setup → Maintenance (Check / Sync) に整理し、セクションコメントを追加
- README.md の Maintenance セクションを Check / Sync に分割し、新コマンドを追記

Closes #37

## Test plan
- [ ] `make vscodecheck` でローカルのみ・リポジトリのみの拡張機能が表示される
- [ ] 差分がない場合は同期済みメッセージが表示される
- [ ] `make vscodesync` で `extensions.txt` がローカルの状態に更新される
- [ ] 同期後に `make vscodecheck` で差分なしが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)