### PR TITLE
docs: Makeターゲットの設計方針（Setup / Maintenance）をREADMEに記載する

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ make init
 
 ## Make
 
+Make targets are organized into the following categories:
+
+- **Setup**: Apply repository settings to local environment (run all at once with `make init`)
+- **Maintenance - Check**: Check for drift between repository and local state (read-only)
+- **Maintenance - Sync**: Reflect current local state back into the repository
+
 ### Setup
 
 Full setup (runs brew + link + macos + vscode-extensions):


### PR DESCRIPTION
## Summary
- Makeセクションの冒頭にSetup / Maintenance の設計方針を追加
- 各カテゴリの役割（Setup = リポ→ローカルの適用、Maintenance-Check = 差分確認、Maintenance-Sync = ローカル→リポの反映）を簡潔に記載

Closes #38

## Test plan
- [ ] READMEの該当箇所を確認し、設計方針が正確に記載されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)