### PR TITLE
enhance: macOS defaults設定を追加する

### DIFF
--- a/init/macos.sh
+++ b/init/macos.sh
@@ -7,19 +7,32 @@ echo "Applying macOS defaults..."
 defaults write com.apple.dock autohide -bool true
 defaults write com.apple.dock magnification -bool true
 defaults write com.apple.dock mineffect -string "scale"
+defaults write com.apple.dock show-recents -bool false
 
 # Finder
 defaults write com.apple.finder FXPreferredViewStyle -string "clmv"
+defaults write com.apple.finder AppleShowAllFiles -bool true
+defaults write NSGlobalDomain AppleShowAllExtensions -bool true
 
 # Keyboard
 defaults write NSGlobalDomain KeyRepeat -int 2
 defaults write NSGlobalDomain InitialKeyRepeat -int 15
 
+# Input
+defaults write NSGlobalDomain NSAutomaticQuoteSubstitutionEnabled -bool false
+defaults write NSGlobalDomain NSAutomaticDashSubstitutionEnabled -bool false
+
 # Trackpad
 defaults write com.apple.AppleMultitouchTrackpad Clicking -bool true
 defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad Clicking -bool true
 
+# Screenshot
+defaults write com.apple.screencapture location -string "$HOME/Screenshots"
+
+# Misc
+defaults write com.apple.desktopservices DSDontWriteNetworkStores -bool true
+
 # Apply changes
-killall Dock Finder
+killall Dock Finder SystemUIServer
 
 echo "macos.sh completed."


### PR DESCRIPTION
## Summary
- スマート引用符/ダッシュの自動変換を無効化（コピペ時のUnicode文字化け防止）
- Finderで隠しファイル・拡張子を常時表示
- Dockの「最近使ったアプリ」を非表示
- スクリーンショット保存先を `~/Screenshots` に変更
- ネットワークドライブでの `.DS_Store` 生成を抑制

Closes #41

## Test plan
- [ ] `make macoscheck` で追加した設定項目が差分として検出されること
- [ ] `make macos` で正常に適用されること
- [ ] 適用後 `make macoscheck` で差分なしとなること

🤖 Generated with [Claude Code](https://claude.com/claude-code)