### PR TITLE
fix: macos_check.shでシェル変数を含む設定値の比較を修正する

### DIFF
--- a/init/macos_check.sh
+++ b/init/macos_check.sh
@@ -20,6 +20,7 @@ while IFS= read -r line; do
             ;;
         -string)
             expected="${expected//\"/}"
+            expected=$(eval echo "$expected")
             ;;
         -int)
             ;;


### PR DESCRIPTION
## Summary
- `macos_check.sh` の `-string` 型 expected 値取得後に `eval echo` でシェル変数を展開するよう修正
- `$HOME/Screenshots` 等の変数を含む設定値で偽の差分が出なくなる

Closes #43

## Test plan
- [ ] `make macoscheck` で screencapture location の偽差分が出ないこと
- [ ] 他の既存設定項目に影響がないこと（差分なしと表示されること）

🤖 Generated with [Claude Code](https://claude.com/claude-code)