### PR TITLE
enhance: VS Code設定を追加する（stickyScroll・bracketPairsガイド・git.autofetch・trimFinalNewlines）

### DIFF
--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -11,6 +11,7 @@
     "explorer.confirmDragAndDrop": false,
     "explorer.confirmDelete": false,
     "git.enableSmartCommit": true,
+    "git.autofetch": true,
     "claudeCode.preferredLocation": "panel",
     "workbench.startupEditor": "none",
     "editor.fontLigatures": true,
@@ -19,8 +20,11 @@
         100
     ],
     "editor.minimap.enabled": false,
+    "editor.stickyScroll.enabled": true,
+    "editor.guides.bracketPairs": true,
     "files.trimTrailingWhitespace": true,
     "files.insertFinalNewline": true,
+    "files.trimFinalNewlines": true,
     "files.autoSave": "onFocusChange",
     "terminal.integrated.hideOnStartup": "never"
 }


### PR DESCRIPTION
## Summary
- `editor.stickyScroll.enabled`: スクロール時にスコープヘッダを上部に固定
- `editor.guides.bracketPairs`: 括弧ペア間にガイド線を表示
- `git.autofetch`: バックグラウンドでfetchしブランチの遅れを検知
- `files.trimFinalNewlines`: `insertFinalNewline`と組み合わせて末尾改行を正規化

Closes #45

## Test plan
- [ ] VS Codeで設定が正しく反映されることを確認
- [ ] `make link`でシンボリックリンクが正しく作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)