### PR TITLE
docs: READMEにstowシンボリックリンクの対応関係を追記する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,12 +10,7 @@ macOS dotfiles repository. Manages Homebrew, Git, Zsh, and VS Code configuration
 
 ### Symlink structure (stow)
 
-`init/link.sh` uses GNU stow to create symlinks:
-
-- `zsh/`, `git/` → `$HOME`
-- `vscode/` → `~/Library/Application Support/Code/User`
-
-Uses `--adopt` to incorporate existing files at the target, then restores repo versions with `git checkout -- .`.
+`init/link.sh` uses GNU stow to create symlinks. See [README.md](README.md#make) for the symlink mapping.
 
 ### Claude Code Skills
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ Create symlinks with stow:
 make link
 ```
 
+| Source | Target |
+|---|---|
+| `zsh/`, `git/` | `$HOME` |
+| `vscode/` | `~/Library/Application Support/Code/User` |
+
+Uses `--adopt` to incorporate existing files, then restores repo versions with `git checkout -- .`.
+
 Apply macOS defaults:
 
 ```bash


### PR DESCRIPTION
## Summary
- READMEの`make link`セクションにシンボリックリンクの対応表（source → target）と`--adopt`の挙動を追記
- CLAUDE.mdの重複記述をREADMEへの参照に置き換えて軽量化

Closes #47

## Test plan
- [ ] READMEの対応表が`init/link.sh`の実装と一致していることを確認
- [ ] CLAUDE.mdからREADMEへのリンクが適切であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)