### PR TITLE
enhance: make check コマンドを追加する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: init brew link macos vscode-extensions macoscheck vscodecheck brewsync vscodesync
+.PHONY: init brew link macos vscode-extensions check macoscheck vscodecheck brewsync vscodesync
 
 # Setup
 init: brew link macos vscode-extensions
@@ -18,6 +18,8 @@ vscode-extensions:
 	@bash init/install-vscode-extensions.sh
 
 # Maintenance - Check
+check: macoscheck vscodecheck
+
 macoscheck:
 	@bash init/macos_check.sh
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ make vscode-extensions
 
 ### Maintenance - Check
 
+Run all check targets at once:
+
+```bash
+make check
+```
+
 Check for drift between macos.sh and current macOS settings:
 
 ```bash

--- a/init/macos_check.sh
+++ b/init/macos_check.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 MACOS_SH="$SCRIPT_DIR/macos.sh"
 
+echo "=== macOS defaults ==="
+echo ""
+
 diff_count=0
 
 while IFS= read -r line; do
@@ -44,3 +47,5 @@ else
     echo "  - macos.sh の設定をMacに適用する場合: make macos"
     echo "  - Mac の現在値を macos.sh に反映する場合: macos.sh を手動編集してください"
 fi
+
+echo ""

--- a/init/vscode_check.sh
+++ b/init/vscode_check.sh
@@ -9,6 +9,9 @@ if ! command -v code &>/dev/null; then
     exit 1
 fi
 
+echo "=== VS Code extensions ==="
+echo ""
+
 local_extensions=$(code --list-extensions | sort)
 repo_extensions=$(sort "$EXTENSIONS_FILE")
 
@@ -42,3 +45,5 @@ else
     echo "  - extensions.txt の拡張機能をインストールする場合: make vscode-extensions"
     echo "  - ローカルの状態を extensions.txt に反映する場合: make vscodesync"
 fi
+
+echo ""


### PR DESCRIPTION
## Summary
- チェック系ターゲット（`macoscheck`, `vscodecheck`）をまとめて実行できる `make check` コマンドを追加
- 各チェックスクリプトにヘッダー（`=== macOS defaults ===` 等）と末尾空行を追加し、出力の視認性を改善
- README に `make check` の説明を追記

Closes #49

## Test plan
- [ ] `make check` で `macoscheck` と `vscodecheck` が順に実行されることを確認
- [ ] 各チェック結果にヘッダーが表示され、結果間にスペースがあることを確認
- [ ] `make macoscheck` / `make vscodecheck` を単体実行しても正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)