### PR TITLE
chore: READMEからMCP Server Configurationセクションを削除する

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,21 +117,3 @@ dotfiles/
     ├── mcp.json           # MCP server configuration
     └── extensions.txt
 ```
-
-## MCP Server Configuration
-
-MCP server configuration is managed in `vscode/mcp.json` (symlinked to `~/Library/Application Support/Code/User/mcp.json` via `make link`).
-
-### Managed Servers
-
-| Server | URL | Auth |
-|---|---|---|
-| Atlassian Rovo MCP Server | https://mcp.atlassian.com/v1/mcp | OAuth (browser) |
-
-### Authentication
-
-On first setup, sign in to the Atlassian server from the MCP Servers section in the VS Code extensions panel (a browser window will open for Atlassian account authentication).
-
-### Not Managed
-
-`~/Library/Application Support/Code/User/mcp/` (downloaded server binary cache) is not tracked in this repository.


### PR DESCRIPTION
## Summary
- READMEのMCP Server Configurationセクション（Managed Servers / Authentication / Not Managed）を削除
- 他のツールと記載粒度を揃え、詳細は `vscode/mcp.json` を参照する形にする

Closes #51

## Test plan
- [ ] READMEの構成が自然であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)