### PR TITLE
chore: READMEのStructureセクションのコメントインデントを修正する

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,13 +98,13 @@ dotfiles/
 ├── Makefile
 ├── Brewfile
 ├── init/
-│   ├── brew.sh                      # Homebrew installation and package management
-│   ├── link.sh                      # Symlink management with stow
-│   ├── macos.sh                     # macOS defaults configuration
-│   ├── macos_check.sh               # Check drift between macos.sh and current settings
-│   ├── install-vscode-extensions.sh # Install VS Code extensions
-│   ├── vscode_check.sh             # Check drift between extensions.txt and local extensions
-│   └── vscode_sync.sh              # Sync local extensions to extensions.txt
+│   ├── brew.sh                       # Homebrew installation and package management
+│   ├── link.sh                       # Symlink management with stow
+│   ├── macos.sh                      # macOS defaults configuration
+│   ├── macos_check.sh                # Check drift between macos.sh and current settings
+│   ├── install-vscode-extensions.sh  # Install VS Code extensions
+│   ├── vscode_check.sh               # Check drift between extensions.txt and local extensions
+│   └── vscode_sync.sh                # Sync local extensions to extensions.txt
 ├── zsh/
 │   ├── .zshrc
 │   └── .zprofile


### PR DESCRIPTION
## Summary
- `init/` 配下のファイルコメント開始位置を最長ファイル名（`install-vscode-extensions.sh`）基準で統一

Closes #53

## Test plan
- [ ] READMEのStructureセクションでコメントの `#` が縦に揃っていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)