### PR TITLE
enhance: トラックパッドのカスタム設定をmacos.shに追加する

### DIFF
--- a/init/macos.sh
+++ b/init/macos.sh
@@ -25,6 +25,15 @@ defaults write NSGlobalDomain NSAutomaticDashSubstitutionEnabled -bool false
 # Trackpad
 defaults write com.apple.AppleMultitouchTrackpad Clicking -bool true
 defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad Clicking -bool true
+defaults write com.apple.AppleMultitouchTrackpad TrackpadThreeFingerDrag -bool true
+defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad TrackpadThreeFingerDrag -bool true
+defaults write com.apple.AppleMultitouchTrackpad TrackpadThreeFingerHorizSwipeGesture -int 0
+defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad TrackpadThreeFingerHorizSwipeGesture -int 0
+defaults write com.apple.AppleMultitouchTrackpad TrackpadThreeFingerVertSwipeGesture -int 0
+defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad TrackpadThreeFingerVertSwipeGesture -int 0
+defaults write NSGlobalDomain com.apple.swipescrolldirection -bool false
+defaults write NSGlobalDomain com.apple.trackpad.scaling -float 3
+defaults write NSGlobalDomain com.apple.scrollwheel.scaling -float 1.7
 
 # Screenshot
 defaults write com.apple.screencapture location -string "$HOME/Screenshots"


### PR DESCRIPTION
## Summary
- 3本指ドラッグの有効化（3本指スワイプジェスチャの無効化を含む）
- ナチュラルスクロールの無効化
- トラックパッド速度・スクロール速度の設定を追加

Closes #59

## Test plan
- [ ] `bash -n init/macos.sh` で構文エラーがないことを確認
- [ ] `make macos` 実行後、システム環境設定でトラックパッド設定が反映されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)