### PR TITLE
enhance: キーボードのカスタム設定をmacos.shに追加する

### DIFF
--- a/init/macos.sh
+++ b/init/macos.sh
@@ -17,6 +17,11 @@ defaults write NSGlobalDomain AppleShowAllExtensions -bool true
 # Keyboard
 defaults write NSGlobalDomain KeyRepeat -int 2
 defaults write NSGlobalDomain InitialKeyRepeat -int 15
+defaults write NSGlobalDomain ApplePressAndHoldEnabled -bool false
+defaults write NSGlobalDomain AppleKeyboardUIMode -int 3
+defaults write NSGlobalDomain NSAutomaticCapitalizationEnabled -bool false
+defaults write NSGlobalDomain NSAutomaticPeriodSubstitutionEnabled -bool false
+defaults write NSGlobalDomain NSAutomaticSpellingCorrectionEnabled -bool false
 
 # Input
 defaults write NSGlobalDomain NSAutomaticQuoteSubstitutionEnabled -bool false


### PR DESCRIPTION
## Summary
- macos.shのKeyboardセクションに5つのカスタム設定を追加
  - 長押しでキーリピート有効化（ApplePressAndHoldEnabled）
  - フルキーボードアクセス有効化（AppleKeyboardUIMode）
  - 自動大文字変換・自動ピリオド挿入・自動スペル修正の無効化

Closes #61

## Test plan
- [ ] `make macos` が正常に完了すること
- [ ] 各設定が `defaults read` で反映されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)