### PR TITLE
enhance: Dock・ダークモードのカスタム設定をmacos.shに追加する

### DIFF
--- a/init/macos.sh
+++ b/init/macos.sh
@@ -8,6 +8,9 @@ defaults write com.apple.dock autohide -bool true
 defaults write com.apple.dock magnification -bool true
 defaults write com.apple.dock mineffect -string "scale"
 defaults write com.apple.dock show-recents -bool false
+defaults write com.apple.dock largesize -int 81
+defaults write com.apple.dock wvous-br-corner -int 14
+defaults write com.apple.dock wvous-br-modifier -int 0
 
 # Finder
 defaults write com.apple.finder FXPreferredViewStyle -string "clmv"
@@ -45,6 +48,7 @@ defaults write com.apple.screencapture location -string "$HOME/Screenshots"
 
 # Misc
 defaults write com.apple.desktopservices DSDontWriteNetworkStores -bool true
+defaults write NSGlobalDomain AppleInterfaceStyle -string "Dark"
 
 # Apply changes
 killall Dock Finder SystemUIServer


### PR DESCRIPTION
## Summary
- Dockセクションに拡大サイズ（largesize）とホットコーナー（右下=クイックメモ）の設定を追加
- Miscセクションにダークモード設定を追加

Closes #62

## Test plan
- [ ] `make macos` が正常に完了すること
- [ ] 各設定が `defaults read` で反映されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)