### PR TITLE
enhance: macos.shの推奨設定を追加する

### DIFF
--- a/init/macos.sh
+++ b/init/macos.sh
@@ -11,11 +11,18 @@ defaults write com.apple.dock show-recents -bool false
 defaults write com.apple.dock largesize -int 81
 defaults write com.apple.dock wvous-br-corner -int 14
 defaults write com.apple.dock wvous-br-modifier -int 0
+defaults write com.apple.dock mru-spaces -bool false
+defaults write com.apple.dock expose-group-apps -bool true
 
 # Finder
 defaults write com.apple.finder FXPreferredViewStyle -string "clmv"
 defaults write com.apple.finder AppleShowAllFiles -bool true
 defaults write NSGlobalDomain AppleShowAllExtensions -bool true
+defaults write com.apple.finder ShowPathbar -bool true
+defaults write com.apple.finder ShowStatusBar -bool true
+defaults write com.apple.finder _FXSortFoldersFirst -bool true
+defaults write com.apple.finder FXEnableExtensionChangeWarning -bool false
+defaults write com.apple.finder FXDefaultSearchScope -string "SCcf"
 
 # Keyboard
 defaults write NSGlobalDomain KeyRepeat -int 2
@@ -44,11 +51,16 @@ defaults write NSGlobalDomain com.apple.trackpad.scaling -float 3
 defaults write NSGlobalDomain com.apple.scrollwheel.scaling -float 1.7
 
 # Screenshot
+mkdir -p "$HOME/Screenshots"
 defaults write com.apple.screencapture location -string "$HOME/Screenshots"
+defaults write com.apple.screencapture disable-shadow -bool true
 
 # Misc
 defaults write com.apple.desktopservices DSDontWriteNetworkStores -bool true
 defaults write NSGlobalDomain AppleInterfaceStyle -string "Dark"
+defaults write NSGlobalDomain NSDocumentSaveNewDocumentsToCloud -bool false
+defaults write NSGlobalDomain NSNavPanelExpandedStateForSaveMode2 -bool true
+defaults write NSGlobalDomain PMPrintingExpandedStateForPrint2 -bool true
 
 # Apply changes
 killall Dock Finder SystemUIServer


### PR DESCRIPTION
## Summary
- Dockセクション: Spacesの自動並び替え無効化、Mission Controlでアプリ別グループ化
- Finderセクション: パスバー・ステータスバー表示、フォルダ優先表示、拡張子変更警告無効、検索範囲をカレントフォルダに
- Screenshotセクション: 保存先ディレクトリの事前作成、ウィンドウキャプチャの影を無効化
- Miscセクション: デフォルト保存先をローカルに、保存・印刷ダイアログを常に展開

Closes #65

## Test plan
- [ ] `make macos` が正常に完了すること
- [ ] 各設定が `defaults read` で反映されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)