### PR TITLE
enhance: WezTermの背景猫画像を削除しウィンドウサイズをデフォルトに戻す

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,7 @@ dotfiles/
 ├── wezterm/.config/wezterm/
 │   ├── wezterm.lua                   # Main configuration
 │   ├── background.lua                # Background layers (gradient + image)
-│   ├── keybinds.lua                  # Key bindings
-│   └── background.png                # Background image (dummy in repo)
+│   └── keybinds.lua                  # Key bindings
 ├── starship/.config/
 │   └── starship.toml                 # Starship prompt configuration
 └── vscode/

--- a/wezterm/.config/wezterm/background.lua
+++ b/wezterm/.config/wezterm/background.lua
@@ -1,7 +1,6 @@
 -- 背景画像のパスを設定
 local wezterm_dir = os.getenv("HOME") .. "/.config/wezterm/"
 local background_night = wezterm_dir .. "background_night.png"
-local background_cat = wezterm_dir .. "background.png"
 
 return {
   -- 背景夜景レイヤー（全面）
@@ -13,17 +12,5 @@ return {
     repeat_y = "NoRepeat",
     opacity = 0.5,                               -- 透明度（0.0〜1.0、低いほど透明）
     hsb = { brightness = 0.6, saturation = 0.9 },  -- 暗めに抑えて文字の可読性を確保
-  },
-  -- 背景猫画像レイヤー（右下）
-  {
-    source = { File = background_cat },
-    width = "310px",
-    height = "238px",
-    repeat_x = "NoRepeat",
-    repeat_y = "NoRepeat",
-    vertical_align = "Bottom",
-    horizontal_align = "Right",
-    opacity = 0.8,                                -- 透明度（0.0〜1.0、低いほど透明）
-    hsb = { brightness = 0.65, saturation = 0.85 }, -- 夜景に馴染むよう暗め・彩度控えめに
   },
 }

--- a/wezterm/.config/wezterm/background.png
+++ b/wezterm/.config/wezterm/background.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:70d93b9d6184538a2e2e36478c1b16588cde07121aab3f62f7a2868c2a55321c
-size 2745731

--- a/wezterm/.config/wezterm/wezterm.lua
+++ b/wezterm/.config/wezterm/wezterm.lua
@@ -16,8 +16,6 @@ config.font_size = 13.0                    -- フォントサイズ
 config.use_ime = true                      -- 日本語IMEを有効化
 config.scrollback_lines = 10000            -- スクロールバック行数
 config.audible_bell = "Disabled"           -- ビープ音を無効化
-config.initial_cols = 120                  -- 初期ウィンドウ幅（列数）
-config.initial_rows = 35                   -- 初期ウィンドウ高さ（行数）
 
 -- 背景
 config.background = background                   -- 背景画像（background.luaで定義）


### PR DESCRIPTION
## Summary
- `background.lua` から猫画像レイヤーを削除し、夜景レイヤーのみ残す
- `wezterm.lua` から `initial_cols` / `initial_rows` を削除して起動時ウィンドウサイズをデフォルト化（`font_size = 13.0` は維持）
- 不要となった `background.png`（リポジトリ内のdummy）を削除し、README のディレクトリツリーからも該当エントリを除去

Closes #67

## Test plan
- [ ] WezTerm起動時に背景から猫画像が消えていること
- [ ] 起動時ウィンドウサイズがWezTermのデフォルトになっていること
- [ ] フォントサイズが従来通り `13.0` で表示されること
- [ ] 夜景レイヤーは引き続き表示されること
- [ ] 設定リロード時にLuaエラーが出ないこと（`CMD+Shift+L` で確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)