### PR TITLE
enhance: WezTerm設定をstow管理に戻しLFSオブジェクトを事前取得する

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,8 @@ dotfiles/
 ├── wezterm/.config/wezterm/
 │   ├── wezterm.lua                   # Main configuration
 │   ├── background.lua                # Background layers (gradient + image)
-│   └── keybinds.lua                  # Key bindings
+│   ├── keybinds.lua                  # Key bindings
+│   └── background_night.png          # Background image (Git LFS)
 ├── starship/.config/
 │   └── starship.toml                 # Starship prompt configuration
 └── vscode/

--- a/init/link.sh
+++ b/init/link.sh
@@ -3,6 +3,12 @@ set -euo pipefail
 
 DOTFILES_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
+# Materialize Git LFS objects in the working tree before stow runs,
+# so binary assets are linked as real files, not 132-byte LFS pointers.
+cd "$DOTFILES_DIR"
+git lfs install --local
+git lfs pull
+
 PACKAGES=(zsh git wezterm starship)
 
 for pkg in "${PACKAGES[@]}"; do


### PR DESCRIPTION
## Summary
- `init/link.sh` の stow 実行前に `git lfs install --local` と `git lfs pull` を追加し、新規マシンでも `background_night.png` が LFS ポインタのまま symlink されないようにする
- `README.md` の Structure セクションに `background_night.png`（Git LFS）を追記し、ディレクトリツリーを実態と一致させる
- `~/.config/wezterm/` 配下の4ファイル（`background.lua`, `wezterm.lua`, `keybinds.lua`, `background_night.png`）をローカルで repo への symlink に置き換え済み

Closes #69

## Test plan
- [ ] `ls -la ~/.config/wezterm/` で4ファイルすべてが symlink になっていることを確認
- [ ] `wc -c ~/.config/wezterm/background_night.png` が `2221322` を返す（LFS ポインタ132Bでない）
- [ ] WezTerm を再起動し、夜景背景が従来通り表示される
- [ ] repo 側で `.lua` を編集すると WezTerm 自動リロードで即反映される
- [ ] `make link` を再実行して no-op で完走する（idempotency）

🤖 Generated with [Claude Code](https://claude.com/claude-code)