### PR TITLE
feat: IntelliJ IDEAのカスタムキーマップをdotfilesで管理する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 SHELL := /bin/bash
 
-.PHONY: init brew link macos vscode-extensions check macoscheck vscodecheck brewsync vscodesync
+.PHONY: init brew link macos vscode-extensions intellij-keymap check macoscheck vscodecheck intellijcheck brewsync vscodesync
 
 # Setup
-init: brew link macos vscode-extensions
+init: brew link macos vscode-extensions intellij-keymap
 
 brew:
 	@bash init/brew.sh
@@ -17,14 +17,20 @@ macos:
 vscode-extensions:
 	@bash init/install-vscode-extensions.sh
 
+intellij-keymap:
+	@bash init/install-intellij-keymap.sh
+
 # Maintenance - Check
-check: macoscheck vscodecheck
+check: macoscheck vscodecheck intellijcheck
 
 macoscheck:
 	@bash init/macos_check.sh
 
 vscodecheck:
 	@bash init/vscode_check.sh
+
+intellijcheck:
+	@bash init/intellij_check.sh
 
 # Maintenance - Sync
 brewsync:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Make targets are organized into the following categories:
 
 ### Setup
 
-Full setup (runs brew + link + macos + vscode-extensions):
+Full setup (runs brew + link + macos + vscode-extensions + intellij-keymap):
 
 ```bash
 make init
@@ -57,6 +57,12 @@ Install VS Code extensions from `vscode/extensions.txt`:
 make vscode-extensions
 ```
 
+Install IntelliJ IDEA keymaps from `intellij/keymaps/` (symlinks into all detected `IdeaIC*` / `IdeaIU*` directories):
+
+```bash
+make intellij-keymap
+```
+
 ### Maintenance - Check
 
 Run all check targets at once:
@@ -75,6 +81,12 @@ Check for differences between `vscode/extensions.txt` and locally installed exte
 
 ```bash
 make vscodecheck
+```
+
+Check for drift between `intellij/keymaps/` and the installed IntelliJ IDEA keymap symlinks:
+
+```bash
+make intellijcheck
 ```
 
 ### Maintenance - Sync
@@ -104,7 +116,9 @@ dotfiles/
 │   ├── macos_check.sh                # Check drift between macos.sh and current settings
 │   ├── install-vscode-extensions.sh  # Install VS Code extensions
 │   ├── vscode_check.sh               # Check drift between extensions.txt and local extensions
-│   └── vscode_sync.sh                # Sync local extensions to extensions.txt
+│   ├── vscode_sync.sh                # Sync local extensions to extensions.txt
+│   ├── install-intellij-keymap.sh    # Symlink IntelliJ IDEA keymaps into JetBrains config dirs
+│   └── intellij_check.sh             # Check drift of IntelliJ IDEA keymap symlinks
 ├── zsh/
 │   ├── .zshrc
 │   └── .zprofile
@@ -118,9 +132,12 @@ dotfiles/
 │   └── background_night.png          # Background image (Git LFS)
 ├── starship/.config/
 │   └── starship.toml                 # Starship prompt configuration
-└── vscode/
-    ├── settings.json
-    ├── keybindings.json
-    ├── mcp.json           # MCP server configuration
-    └── extensions.txt
+├── vscode/
+│   ├── settings.json
+│   ├── keybindings.json
+│   ├── mcp.json           # MCP server configuration
+│   └── extensions.txt
+└── intellij/
+    └── keymaps/
+        └── macOS.xml                 # IntelliJ IDEA custom keymap
 ```

--- a/init/install-intellij-keymap.sh
+++ b/init/install-intellij-keymap.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -euo pipefail
+
+DOTFILES_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+KEYMAP_SRC_DIR="$DOTFILES_DIR/intellij/keymaps"
+JETBRAINS_DIR="$HOME/Library/Application Support/JetBrains"
+
+if [[ ! -d "$JETBRAINS_DIR" ]]; then
+    echo "JetBrains directory not found: $JETBRAINS_DIR (skipping)"
+    exit 0
+fi
+
+shopt -s nullglob
+PRODUCT_DIRS=("$JETBRAINS_DIR"/IdeaIC* "$JETBRAINS_DIR"/IdeaIU*)
+shopt -u nullglob
+
+if [[ ${#PRODUCT_DIRS[@]} -eq 0 ]]; then
+    echo "No IntelliJ IDEA installation found under $JETBRAINS_DIR (skipping)"
+    exit 0
+fi
+
+for product_dir in "${PRODUCT_DIRS[@]}"; do
+    [[ -d "$product_dir" ]] || continue
+    keymaps_dir="$product_dir/keymaps"
+    mkdir -p "$keymaps_dir"
+
+    for src in "$KEYMAP_SRC_DIR"/*.xml; do
+        [[ -e "$src" ]] || continue
+        name="$(basename "$src")"
+        dest="$keymaps_dir/$name"
+
+        if [[ -L "$dest" ]]; then
+            current_target="$(readlink "$dest")"
+            if [[ "$current_target" == "$src" ]]; then
+                echo "OK: $dest -> $src"
+                continue
+            fi
+            echo "Re-linking $dest (was -> $current_target)"
+            rm "$dest"
+        elif [[ -e "$dest" ]]; then
+            backup="$dest.bak"
+            echo "Backing up existing $dest -> $backup"
+            mv "$dest" "$backup"
+        fi
+
+        ln -s "$src" "$dest"
+        echo "Linked: $dest -> $src"
+    done
+done
+
+echo "install-intellij-keymap.sh completed."

--- a/init/intellij_check.sh
+++ b/init/intellij_check.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -euo pipefail
+
+DOTFILES_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+KEYMAP_SRC_DIR="$DOTFILES_DIR/intellij/keymaps"
+JETBRAINS_DIR="$HOME/Library/Application Support/JetBrains"
+
+echo "=== IntelliJ IDEA keymaps ==="
+echo ""
+
+if [[ ! -d "$JETBRAINS_DIR" ]]; then
+    echo "JetBrains directory not found: $JETBRAINS_DIR"
+    exit 0
+fi
+
+shopt -s nullglob
+PRODUCT_DIRS=("$JETBRAINS_DIR"/IdeaIC* "$JETBRAINS_DIR"/IdeaIU*)
+shopt -u nullglob
+
+if [[ ${#PRODUCT_DIRS[@]} -eq 0 ]]; then
+    echo "No IntelliJ IDEA installation found under $JETBRAINS_DIR"
+    exit 0
+fi
+
+drift_count=0
+
+for product_dir in "${PRODUCT_DIRS[@]}"; do
+    [[ -d "$product_dir" ]] || continue
+    product_name="$(basename "$product_dir")"
+    keymaps_dir="$product_dir/keymaps"
+
+    for src in "$KEYMAP_SRC_DIR"/*.xml; do
+        [[ -e "$src" ]] || continue
+        name="$(basename "$src")"
+        dest="$keymaps_dir/$name"
+
+        if [[ ! -e "$dest" && ! -L "$dest" ]]; then
+            echo "MISSING: $product_name/keymaps/$name"
+            drift_count=$((drift_count + 1))
+            continue
+        fi
+
+        if [[ -L "$dest" ]]; then
+            current_target="$(readlink "$dest")"
+            if [[ "$current_target" == "$src" ]]; then
+                echo "OK: $product_name/keymaps/$name"
+            else
+                echo "DRIFT (symlink target): $product_name/keymaps/$name -> $current_target"
+                drift_count=$((drift_count + 1))
+            fi
+        else
+            echo "DRIFT (not a symlink): $product_name/keymaps/$name"
+            if ! diff -q "$src" "$dest" >/dev/null 2>&1; then
+                echo "  content differs from $src"
+            fi
+            drift_count=$((drift_count + 1))
+        fi
+    done
+done
+
+echo ""
+if [[ $drift_count -eq 0 ]]; then
+    echo "No drift detected."
+else
+    echo "Drift detected: $drift_count item(s). Run 'make intellij-keymap' to reconcile."
+    exit 1
+fi

--- a/intellij/keymaps/macOS.xml
+++ b/intellij/keymaps/macOS.xml
@@ -1,0 +1,22 @@
+<keymap version="1" name="macOS コピー" parent="Mac OS X 10.5+">
+  <action id="ClickLink">
+    <mouse-shortcut keystroke="Force touch" />
+    <mouse-shortcut keystroke="button2" />
+  </action>
+  <action id="Console.TableResult.GotoReferencingResult">
+    <mouse-shortcut keystroke="Force touch" />
+    <mouse-shortcut keystroke="button2" />
+  </action>
+  <action id="GotoDeclaration">
+    <mouse-shortcut keystroke="Force touch" />
+    <mouse-shortcut keystroke="button2" />
+    <keyboard-shortcut first-keystroke="shift meta b" />
+    <mouse-shortcut keystroke="shift meta button1" />
+  </action>
+  <action id="GotoTypeDeclaration">
+    <keyboard-shortcut first-keystroke="shift ctrl b" />
+    <keyboard-shortcut first-keystroke="meta b" />
+    <mouse-shortcut keystroke="meta button1" />
+  </action>
+  <action id="org.intellij.plugins.markdown.ui.actions.styling.ToggleBoldAction" />
+</keymap>


### PR DESCRIPTION
## Summary
- `intellij/keymaps/macOS.xml` を新設し、IntelliJ IDEA のカスタムキーマップをリポジトリ管理対象に追加
- `init/install-intellij-keymap.sh` を追加し、`IdeaIC*` / `IdeaIU*` 配下の `keymaps/` へ symlink を張る冪等スクリプトを実装（既存通常ファイルは `.bak` に退避、IDEA 未インストール環境では警告のみで正常終了）
- `init/intellij_check.sh` を追加し、symlink がリポジトリを指しているかの drift 検出を実装
- `Makefile` に `intellij-keymap` / `intellijcheck` ターゲットを追加し、それぞれ `init` / `check` の依存に組み込み
- `README.md` の Setup・Maintenance - Check セクションと Structure ツリーを更新

Closes #71

## Test plan
- [x] `make intellij-keymap` 実行で `~/Library/Application Support/JetBrains/IdeaIC2025.1/keymaps/macOS.xml` が repo を指す symlink になり、既存ファイルは `.bak` に退避されることを確認
- [x] 再実行が冪等（`OK` で skip）であることを確認
- [x] `make intellijcheck` で `No drift detected.` が表示されることを確認
- [ ] 新マシン（IDEA 未インストール）で `make init` が失敗せずに通ることを確認（要動作環境）
- [ ] IDE を起動して、設定 > キーマップから "macOS コピー" が選択でき、参照ジャンプ系のショートカットが機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)