### PR TITLE
enhance: VSCodeの拡張機能レコメンド通知を無効化する

### DIFF
--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -26,5 +26,6 @@
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
     "files.autoSave": "onFocusChange",
-    "terminal.integrated.hideOnStartup": "never"
+    "terminal.integrated.hideOnStartup": "never",
+    "extensions.ignoreRecommendations": true
 }


### PR DESCRIPTION
## Summary
- `vscode/settings.json` に `extensions.ignoreRecommendations: true` を追加し、VSCodeの拡張機能レコメンド通知を抑制する

## Test plan
- [ ] `make init` 後にVSCodeを起動し、拡張機能のレコメンド通知が表示されないことを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)