### PR TITLE
enhance: Claude Code 関連設定を調整する

### DIFF
--- a/git/.gitignore_global
+++ b/git/.gitignore_global
@@ -1,2 +1,4 @@
 # OS
 .DS_Store
+
+**/.claude/settings.local.json

--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -12,7 +12,6 @@
     "explorer.confirmDelete": false,
     "git.enableSmartCommit": true,
     "git.autofetch": true,
-    "claudeCode.preferredLocation": "panel",
     "workbench.startupEditor": "none",
     "editor.fontLigatures": true,
     "editor.formatOnSave": true,
@@ -27,5 +26,6 @@
     "files.trimFinalNewlines": true,
     "files.autoSave": "onFocusChange",
     "terminal.integrated.hideOnStartup": "never",
-    "extensions.ignoreRecommendations": true
+    "extensions.ignoreRecommendations": true,
+    "claudeCode.preferredLocation": "sidebar"
 }


### PR DESCRIPTION
## Summary
- VS Code の Claude Code 表示位置を `panel` から `sidebar` に変更
- `.claude/settings.local.json` をグローバル gitignore に追加

## Test plan
- [ ] VS Code 再読み込み後、Claude Code がサイドバーに表示される
- [ ] `.claude/settings.local.json` が git の追跡対象外になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)