### PR TITLE
enhance: WezTerm 背景を暗くして可読性を向上する

### DIFF
--- a/wezterm/.config/wezterm/background.lua
+++ b/wezterm/.config/wezterm/background.lua
@@ -11,6 +11,15 @@ return {
     repeat_x = "NoRepeat",
     repeat_y = "NoRepeat",
     opacity = 0.5,                               -- 透明度（0.0〜1.0、低いほど透明）
-    hsb = { brightness = 0.6, saturation = 0.9 },  -- 暗めに抑えて文字の可読性を確保
+    hsb = { brightness = 0.25, saturation = 0.9 },  -- 暗めに抑えて文字の可読性を確保
+  },
+  -- 暗いオーバーレイレイヤー（最前面）
+  {
+    source = { Color = "#000000" },              -- 単色の黒
+    width = "100%",
+    height = "100%",
+    repeat_x = "NoRepeat",
+    repeat_y = "NoRepeat",
+    opacity = 0.7,                               -- 画像全体に黒を重ね、明るいスポットを一律に抑制
   },
 }

--- a/wezterm/.config/wezterm/wezterm.lua
+++ b/wezterm/.config/wezterm/wezterm.lua
@@ -19,7 +19,7 @@ config.audible_bell = "Disabled"           -- ビープ音を無効化
 
 -- 背景
 config.background = background                   -- 背景画像（background.luaで定義）
-config.window_background_opacity = 0.88          -- ウィンドウの透過度
+config.window_background_opacity = 0.95          -- ウィンドウの透過度
 config.macos_window_background_blur = 25         -- macOSの背景ぼかし強度
 config.window_background_gradient = {
   colors = { "#000000" },                        -- グラデーション（黒単色）


### PR DESCRIPTION
## Summary
- 背景画像の `brightness` を `0.6` → `0.25` に下げ、全体を暗くした
- 画像の上に黒の半透明オーバーレイ層（`opacity 0.7`）を追加し、タワー・ランプ等の明るいスポットを一律に抑制
- `window_background_opacity` を `0.88` → `0.95` に上げ、文字のコントラストを確保

> 元画像のハイライト（タワー・ランプ）自体を抑える根本対応は別Issueで対応する。

Closes #79

## Test plan
- [ ] WezTerm 再読み込み後、背景が暗くなり明るいスポットが目立たないことを確認
- [ ] 各カラースキーム/前景色でテキストが読みやすいことを確認
- [ ] 暗くしすぎて背景が完全に潰れていない（バランスが取れている）ことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)